### PR TITLE
[FIX] Don't divide requested memory per core (for PBS)

### DIFF
--- a/submit.py
+++ b/submit.py
@@ -182,7 +182,8 @@ class SubmitPBS(Submit):
                 # It is easier to request more cpus rather than more memory
                 while mem_requested > mem_per_core:
                     num_cpus += 1
-                    mem_requested = mem_advertised/num_cpus
+                    #@samary: Don't divide per core
+                    #mem_requested = mem_advertised/num_cpus
             walltime = int(self.config["Cluster"]["walltime_hrs"])
 
 


### PR DESCRIPTION
The requested memory is used for the whole job. We don't need to divide by the number of core.
BTW, this limitation on RAM never worked without cgroups (on our site)